### PR TITLE
fixed wrong max handling

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -67,7 +67,7 @@ const updateNodeSize = (plugin: NodeAutoResizePlugin) => {
 					nodes,
 				}, {
 					adjustedHeight: height - originalHeight,
-					adjustedWidth: (width > plugin.settings.maxWidth ? editor.node.width : width) - originalWidth,
+					adjustedWidth: plugin.settings.widthAutoResize ? (Math.max(width, plugin.settings.maxWidth) - originalWidth) : 0,
 				});
 				
 				editor.node.resize({


### PR DESCRIPTION
#### Small thing here
If you re-read the line you know what went wrong. If the width should increase but flows over the max width, it should be capped at the max-width (maxWidth-currentWidth) instead of (what previously happened) stay at the currentWidth. 

The width expansion request is still valid, it should increase, even for a tiny but, but stop at the cap. It should NOT stop at the point it was where it then will hit the cap.

TL;DR consistency with setting a maxWidth