### PR TITLE
Fix canvas node vertical scrollbar by adding height padding. Update main.ts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ const updateNodeSize = (plugin: NodeAutoResizePlugin) => {
 			const editor = v.state.field(editorInfoField);
 			if (editor?.node) {
 				console.log(editor.node);
-				const EXTRA_VERTICAL_PADDING = 16;
+				const EXTRA_VERTICAL_PADDING = 18;
 				const height = (v.view as EditorView).contentHeight + EXTRA_VERTICAL_PADDING;
 
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,9 @@ const updateNodeSize = (plugin: NodeAutoResizePlugin) => {
 			const editor = v.state.field(editorInfoField);
 			if (editor?.node) {
 				console.log(editor.node);
-				const height = (v.view as EditorView).contentHeight;
+				const EXTRA_VERTICAL_PADDING = 16;
+				const height = (v.view as EditorView).contentHeight + EXTRA_VERTICAL_PADDING;
+
 
 				if (editor.node.height === height) return;
 				let width = editor.node.width;


### PR DESCRIPTION
Adds a small vertical padding to calculated canvas node height.

This prevents vertical scrollbars from appearing when a node has 3+ lines of text.
The change is minimal and does not affect horizontal resizing.
